### PR TITLE
Fix argument escaping in Messages event handler

### DIFF
--- a/src/Hubot Event Handler.applescript
+++ b/src/Hubot Event Handler.applescript
@@ -2,9 +2,14 @@ using terms from application "Messages"
 	
 	on message received theMessage from theBuddy for theChat
 		set qMessage to quoted form of theMessage
-		set qHandle to handle of theBuddy
-		set qName to first name of theBuddy
-		set qScript to "$HUBOT_DIR/node_modules/hubot-imessage/src/messageReceiver.coffee"
+		set qHandle to quoted form of (handle of theBuddy as string)
+		set qScript to quoted form of "$HUBOT_PATH/node_modules/hubot-imessage/src/messageReceiver.coffee"
+		
+		if (first name of theBuddy) is missing value then
+			set qName to quoted form of ""
+		else
+			set qName to quoted form of (first name of theBuddy as string)
+		end if
 		
 		do shell script "export PATH=/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin && " & qScript & " " & qHandle & " " & qMessage & " " & qName
 	end message received
@@ -90,4 +95,3 @@ using terms from application "Messages"
 	end completed file transfer
 	
 end using terms from
-

--- a/src/imessage.coffee
+++ b/src/imessage.coffee
@@ -2,11 +2,14 @@
 AppleScript = require('applescript')
 path = require('path')
 
-Redis = require("redis")
+Redis = require('redis')
 Pubsub = Redis.createClient()
-Pubsub.subscribe('hubot:incoming')
+Pubsub.subscribe('hubot:incoming-imessage')
 
 class iMessageAdapter extends Adapter
+  constructor: (robot) ->
+    @robot = robot
+
   send: (envelope, strings...) ->
     user = envelope.user.id
     if user in @allowedUsers
@@ -15,21 +18,25 @@ class iMessageAdapter extends Adapter
         AppleScript.execFile script,
           [user, message],
           (err, rtn) ->
+    else
+      @robot.logger.info 'Refusing to send message to unauthorized iMessage user ' + user
 
   reply: (envelope, strings...) ->
     @send envelope, strings...
 
   run: ->
-    @allowedUsers = process.env.HUBOT_IMESSAGE_HANDLES.split(",")
+    @allowedUsers = process.env.HUBOT_IMESSAGE_HANDLES.split(',')
     Pubsub.on 'message', (channel, dataString) =>
       data = JSON.parse(dataString)
       if data.userId in @allowedUsers
-        user = @userForId data.userId
+        user = @robot.brain.userForId(data.userId)
         user.name = data.name
-        user.room = "iMessage"
+        user.room = 'iMessage'
 
         msg = "#{@robot.name} #{data.message}"
         @receive new TextMessage(user, msg)
+      else
+        @robot.logger.info 'Ignoring message from unauthorized iMessage user ' + data.userId
     @emit 'connected'
 
 exports.use = (robot) ->

--- a/src/messageReceiver.coffee
+++ b/src/messageReceiver.coffee
@@ -1,17 +1,15 @@
 #!/usr/bin/env coffee
 
-console.log "Publishing!"
-Redis = require("redis")
+Redis = require('redis')
 Pubsub = Redis.createClient()
 
 # The 'node_redis' package doesn't let you specify
 # a callback for publish() unless it's part of a multi() chain.
 Pubsub.multi()
-  .publish('hubot:incoming', JSON.stringify {
+  .publish('hubot:incoming-imessage', JSON.stringify {
     message: process.argv[process.argv.length-2]
     userId: process.argv[process.argv.length-3]
     name: process.argv[process.argv.length-1]
   }).exec (err, replies) ->
     process.exit(err ? 1 : 0)
-
 


### PR DESCRIPTION
If a message is received from a user with no first name, AppleScript will set the name to "missing value", and the space will split this into two arguments passed to the `messageReceived.coffee` script.

The patch quotes all command line arguments, and specifically handles missing names (since the user may not be in the address book).
